### PR TITLE
”任意”背景色の修正

### DIFF
--- a/app/assets/stylesheets/users/_session3.scss
+++ b/app/assets/stylesheets/users/_session3.scss
@@ -12,6 +12,9 @@
     padding: 3px;
     margin-left: 1em;
   }
+  .optional {
+    background-color: gray;
+  }
   .box {
     margin-top: 24px;
   }


### PR DESCRIPTION
#What
入力項目が任意の部分のアイコン背景色の修正
https://gyazo.com/2ab3bc416024693a0f51ec8e1cdb7e8f
#Why
ユーザーに入力必須項目であると誤解を与える可能性があるため
