### PR TITLE
カラムの変更(userとaddress)

### DIFF
--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -24,14 +24,17 @@ class SignupController < ApplicationController
 
   def session4
     # session3で入力された値をsessionに保存
-    session[:name] = user_params[:name]
-    session[:name_kana] = user_params[:name_kana]
+    session[:first_name] = user_params[:first_name]
+    session[:last_name] = user_params[:last_name]
+    session[:first_name_kana] = user_params[:first_name_kana]
+    session[:last_name_kana] = user_params[:last_name_kana]
     @user = User.new 
     session[:postal_code] = address_params[:postal_code]
     session[:prefecture] = address_params[:prefecture]
     session[:city] = address_params[:city]
     session[:house_number] = address_params[:house_number]
     session[:building] = address_params[:building]
+    session[:tel] = address_params[:tel]
     @address = Address.new
   end
 
@@ -45,8 +48,10 @@ class SignupController < ApplicationController
       # session2のデータ
       tel: session[:tel], 
       # session3のデータ
-      name: session[:name], 
-      name_kana: session[:name_kana], 
+      first_name: session[:first_name], 
+      last_name: session[:last_name], 
+      first_name_kana: session[:first_name_kana], 
+      last_name_kana: session[:last_name_kana], 
     )
       
     @user.save      #@user.saveでセーブしuser.idを取得
@@ -61,6 +66,7 @@ class SignupController < ApplicationController
       city: session[:city], 
       house_number: session[:house_number], 
       building: session[:building],
+      tel: session[:tel],
       user_id: @user.id
     )
 
@@ -80,11 +86,11 @@ class SignupController < ApplicationController
   private
   # 許可するキーを設定
   def user_params
-    params.require(:user).permit(:email, :password, :nickname, :tel, :birthday, :name_kana, :name)
+    params.require(:user).permit(:email, :password, :nickname, :tel, :birthday, :first_name, :last_name, :first_name_kana, :last_name_kana)
   end
 
   def address_params
-    params.require(:user).require(:addresses).permit(:postal_code,:prefecture,:city,:house_number,:building )
+    params.require(:user).require(:addresses).permit(:postal_code, :prefecture, :city, :house_number, :building, :tel )
   end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
         #  :omniauthable
   validates :email, 
             :nickname,
-            :tel, :birthday, :name_kana,  :name,
+            :tel, :birthday, :first_name_kana, :last_name_kana,  :first_name, :last_name,
             presence: true
 
         

--- a/app/views/signup/session1.html.haml
+++ b/app/views/signup/session1.html.haml
@@ -30,21 +30,6 @@
         %p 安心・安全にご利用いただくために、お客様の本人
         %p 情報の登録にご協力ください。他のお客様に公開さ
         %p れることはありません。
-      -# .sign-up-session1__body__contents__robot
-      -#   私はロボットではありません
-      -#   .sign-up-session1__body__contents__name__title
-      -#     お名前（全角）
-      -#     %span 必須
-      -#   .sign-up-session1__body__contents__name__input
-      -#     = f.text_field :name, class: "form family-name-form", placeholder: "例）山田"
-      -#     = f.text_field :name, class: "form last-name-form", placeholder: "例）花子"
-      -# .sign-up-session1__body__contents__name-kana
-        -# .sign-up-session1__body__contents__name-kana__title
-        -#   お名前カナ（全角）
-        -#   %span 必須
-        -# .sign-up-session1__body__contents__name-kana__form 
-        -#   = f.text_field :name_kana, class:"form family-name-kana-form", placeholder: "例）ヤマダ"
-        -#   = f.text_field :name_kana, class:"form last-name-kana-form", placeholder: "例）ハナコ"
       .sign-up-session1__body__contents__birthday
         .sign-up-session1__body__contents__birthday__title
           生年月日

--- a/app/views/signup/session3.html.haml
+++ b/app/views/signup/session3.html.haml
@@ -12,15 +12,15 @@
           お名前
           %span{class: "required"}必須
         .sign-up-session3__body__contents__name__form
-          = f.text_field :name, class: "form family-name-form", placeholder: "例）山田"
-          = f.text_field :name, class: "form last-name-form", placeholder: "例）花子"
+          = f.text_field :first_name, class: "form family-name-form", placeholder: "例）山田"
+          = f.text_field :last_name, class: "form last-name-form", placeholder: "例）花子"
       .sign-up-session3__body__contents__name-kana.box
         .sign-up-session3__body__contents__name-kana__title
           お名前カナ
           %span{class: "required"}必須
         .sign-up-session3__body__contents__name-kana__form
-          = f.text_field :name_kana, class: "form family-name-kana-form", placeholder: "例）ヤマダ"
-          = f.text_field :name_kana, class: "form last-name-kana-form", placeholder: "例）ハナコ"
+          = f.text_field :first_name_kana, class: "form family-name-kana-form", placeholder: "例）ヤマダ"
+          = f.text_field :last_name_kana, class: "form last-name-kana-form", placeholder: "例）ハナコ"
       .sign-up-session3__body__contents__postal.box
         = f.fields_for :addresses  do |i|
           .sign-up-session3__body__contents__postal__title

--- a/db/migrate/20200110082419_devise_create_users.rb
+++ b/db/migrate/20200110082419_devise_create_users.rb
@@ -7,9 +7,11 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.0]
       t.string :nickname,           null: false
       t.string :email,              null: false, default: ""
       t.string :encrypted_password, null: false, default: ""
-      t.string  :name,              null: false
-      t.string  :name_kana,         null: false
-      t.integer :tel,               null: false
+      t.string  :first_name,              null: false
+      t.string  :last_name,              null: false
+      t.string  :first_name_kana,         null: false
+      t.string  :last_name_kana,         null: false
+      t.string  :tel,               null: false
       t.date    :birthday,          null: false
       t.text    :self_introduction
       t.integer :point,             default: 0

--- a/db/migrate/20200110093109_create_addresses.rb
+++ b/db/migrate/20200110093109_create_addresses.rb
@@ -1,11 +1,12 @@
 class CreateAddresses < ActiveRecord::Migration[5.0]
   def change
     create_table :addresses do |t|
-      t.integer    :postal_code,  null: false
+      t.string    :postal_code,  null: false
       t.integer    :prefecture,   null: false
       t.string     :city,         null: false
       t.string     :house_number, null: false
       t.string     :building
+      t.string     :tel
       t.references :user,         foreign_key: true
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,11 +13,12 @@
 ActiveRecord::Schema.define(version: 20200110094343) do
 
   create_table "addresses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.integer  "postal_code",  null: false
+    t.string   "postal_code",  null: false
     t.integer  "prefecture",   null: false
     t.string   "city",         null: false
     t.string   "house_number", null: false
     t.string   "building"
+    t.string   "tel"
     t.integer  "user_id"
     t.datetime "created_at",   null: false
     t.datetime "updated_at",   null: false
@@ -87,9 +88,11 @@ ActiveRecord::Schema.define(version: 20200110094343) do
     t.string   "nickname",                                          null: false
     t.string   "email",                                default: "", null: false
     t.string   "encrypted_password",                   default: "", null: false
-    t.string   "name",                                              null: false
-    t.string   "name_kana",                                         null: false
-    t.integer  "tel",                                               null: false
+    t.string   "first_name",                                        null: false
+    t.string   "last_name",                                         null: false
+    t.string   "first_name_kana",                                   null: false
+    t.string   "last_name_kana",                                    null: false
+    t.string   "tel",                                               null: false
     t.date     "birthday",                                          null: false
     t.text     "self_introduction",      limit: 65535
     t.integer  "point",                                default: 0

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,8 +4,10 @@ FactoryBot.define do
     email                 { Faker::Internet.free_email }
     password              { "$2a$11$n79OHUThP67eEGcMxKKprOVBf76/wM" }
     password_confirmation { "$2a$11$n79OHUThP67eEGcMxKKprOVBf76/wM" }
-    name                  { "中村" }
-    name_kana             { "なかむら" }
+    first_name                  { "中村" }
+    last_name                  { "花子" }
+    first_name_kana             { "ナカムラ" }
+    last_name_kana             { "ハナコ" }
     tel                   { "9999" }
     birthday              { "2020-11-11" }
     self_introduction     { "こんにちは" }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -14,15 +14,27 @@ describe User do
     end
 
     it "is invalid without a name" do
-      user = build(:user, name: nil)
+      user = build(:user, first_name: nil)
       user.valid?
-      expect(user.errors[:name]).to include("を入力してください")
+      expect(user.errors[:first_name]).to include("を入力してください")
+    end
+
+    it "is invalid without a name" do
+      user = build(:user, last_name: nil)
+      user.valid?
+      expect(user.errors[:last_name]).to include("を入力してください")
     end
     
     it "is invalid without a name_kana" do
-      user = build(:user, name_kana: nil)
+      user = build(:user, first_name_kana: nil)
       user.valid?
-      expect(user.errors[:name_kana]).to include("を入力してください")
+      expect(user.errors[:first_name_kana]).to include("を入力してください")
+    end
+
+    it "is invalid without a name_kana" do
+      user = build(:user, last_name_kana: nil)
+      user.valid?
+      expect(user.errors[:last_name_kana]).to include("を入力してください")
     end
 
     it "is invalid without a tel" do


### PR DESCRIPTION
#What
userカラムの変更： [ name　→　first_nameとlast_nameに変更 ]                        
                                   [ name_kana  →   first_name_kanaとlast_name_kanaに変更 ]
                                   [ telのinteger型　→　string型に変更] 
addressカラムの追加：  telカラム(string型）を追加

#Why
ユーザー登録を行う際に名字と名前を分けるため。telがinteger型だと0から始まる数字が判定されず消えてしまい正確な電話番号を登録できないため。