### PR TITLE
本人情報address編集と新規登録のルートパスを付与

### DIFF
--- a/app/assets/stylesheets/users/_register.scss
+++ b/app/assets/stylesheets/users/_register.scss
@@ -77,7 +77,7 @@
           background-color: white;
           border: 1px solid gray;
           position: relative;
-          .prefectures{
+          #address_prefecture{
             position: absolute;
             width: 530px;
             height: 40px;
@@ -112,7 +112,8 @@
       width: 570px;
       height: 50px;
       margin: 10px auto;
-      .register{
+      input.register{
+        width: 550px;
         display: block;
         text-align: center;
         line-height: 50px;

--- a/app/controllers/mypage_controller.rb
+++ b/app/controllers/mypage_controller.rb
@@ -25,6 +25,18 @@ class MypageController < ApplicationController
     unless current_user.id == @user.id
       return_back and return
     end
+    @user = current_user
+    @address = Address.find_by(user_id: @user.id)
+  end
+
+  def register_edit
+    unless current_user.id == @user.id
+      return_back and return
+    end
+    @user = current_user
+    @address = Address.find_by(user_id: @user.id)
+    @address.update(address_params)
+    redirect_to register_mypage_index_path(current_user.id)
   end
 
   def logout
@@ -39,5 +51,9 @@ class MypageController < ApplicationController
 
   def profile_params
     params.require(:user).permit(:self_introduction)
+  end
+
+  def address_params
+    params.require(:address).permit(:postal_code, :prefecture, :city, :house_number, :building, :tel ).merge(user_id: current_user.id)
   end
 end

--- a/app/views/mypage/register.html.haml
+++ b/app/views/mypage/register.html.haml
@@ -3,120 +3,75 @@
   = render "shared/header"
   .main__container
     = render 'users/side_bar' 
-    .main__container__r-container
-      .main__container__r-container__header
-        本人情報の登録
-      .main__container__r-container__register
-        .main__container__r-container__register__upload
-          %p お客さまの本人情報をご登録ください。
-          %p 登録されたお名前・生年月日を変更する場合、本人確認書類の提出が必要になります。
-          = link_to "#", class:"verification" do
-            本人確認書類のアッロードについて
-            %i.fas.fa-chevron-right
+    = form_for @address, url: register_edit_mypage_index_path(current_user), method: :patch do |f|
+      .main__container__r-container
 
-        .main__container__r-container__register__form
-          お名前
-        .main__container__r-container__register__info
-          = @user.first_name
-          = @user.last_name
-        .main__container__r-container__register__form
-          お名前カナ
-        .main__container__r-container__register__info
-          = @user.first_name_kana
-          = @user.last_name_kana
-        .main__container__r-container__register__form
-          生年月日
-        .main__container__r-container__register__info
-          = @user.birthday
-        .main__container__r-container__register__form
-          .main__container__r-container__register__form__place
-            郵便番号
-          .main__container__r-container__register__form__any
-            任意
-        .main__container__r-container__register__form__edit
-          %input{type: "text", name: "place", size: "50", class:"person"}
-        .main__container__r-container__register__form
-          .main__container__r-container__register__form__place
-            都道府県
-          .main__container__r-container__register__form__any
-            任意
-        .main__container__r-container__register__form__p-edit
-          %rabel{name:"p-rabel",class:"label"}
-            %select{name:"prefectures",class:"prefectures"}
-              %option{value:"1"} 北海道
-              %option{value:"2"} 青森県
-              %option{value:"3"} 岩手県
-              %option{value:"4"} 宮城県
-              %option{value:"5"} 秋田県
-              %option{value:"6"} 山形県
-              %option{value:"7"} 福島県
-              %option{value:"8"} 東京都
-              %option{value:"9"} 神奈川県
-              %option{value:"10"} 埼玉県
-              %option{value:"11"} 千葉県
-              %option{value:"12"} 茨城県
-              %option{value:"13"} 栃木県
-              %option{value:"14"} 群馬県
-              %option{value:"15"} 山梨県
-              %option{value:"16"} 新潟県
-              %option{value:"17"} 長野県
-              %option{value:"18"} 富山県
-              %option{value:"19"} 石川県
-              %option{value:"20"} 福井県
-              %option{value:"21"} 愛知県
-              %option{value:"22"} 岐阜県
-              %option{value:"23"} 静岡県
-              %option{value:"24"} 三重県
-              %option{value:"25"} 大阪府
-              %option{value:"26"} 兵庫県
-              %option{value:"27"} 京都府
-              %option{value:"28"} 滋賀県
-              %option{value:"29"} 奈良県
-              %option{value:"30"} 和歌山県
-              %option{value:"31"} 鳥取県
-              %option{value:"32"} 島根県
-              %option{value:"33"} 岡山県
-              %option{value:"34"} 広島県
-              %option{value:"35"} 山口県
-              %option{value:"36"} 徳島県
-              %option{value:"37"} 香川県
-              %option{value:"38"} 愛媛県
-              %option{value:"39"} 高知県
-              %option{value:"40"} 福岡県
-              %option{value:"41"} 佐賀県
-              %option{value:"42"} 長崎県
-              %option{value:"43"} 熊本県
-              %option{value:"44"} 大分県
-              %option{value:"45"} 宮城県
-              %option{value:"46"} 鹿児島県
-              %option{value:"47"} 沖縄県
-            %i.fas.fa-chevron-down
-        .main__container__r-container__register__form
-          .main__container__r-container__register__form__place
-            市町村
-          .main__container__r-container__register__form__any
-            任意
-        .main__container__r-container__register__form__edit
-          %input{type: "text", name: "place", size: "50", class:"person"}
-        .main__container__r-container__register__form
-          .main__container__r-container__register__form__place
-            番地
-          .main__container__r-container__register__form__any
-            任意
-        .main__container__r-container__register__form__edit
-          %input{type: "text", name: "place", size: "50", class:"person"}
-        .main__container__r-container__register__form
-          .main__container__r-container__register__form__place
-            建物名
-          .main__container__r-container__register__form__any
-            任意
-        .main__container__r-container__register__form__edit
-          %input{type: "text", name: "place", size: "50", class:"person"}
-      .main__container__r-container__register__btn
-        =link_to '#', class:'register' do
-          登録する
-      .main__container__r-container__register__r-info
-        = link_to "#", class:"register-info" do
-          本人情報の登録について
-          %i.fas.fa-chevron-right
+        .main__container__r-container__header
+          本人情報の登録
+        .main__container__r-container__register
+          .main__container__r-container__register__upload
+            %p お客さまの本人情報をご登録ください。
+            %p 登録されたお名前・生年月日を変更する場合、本人確認書類の提出が必要になります。
+            = link_to "#", class:"verification" do
+              本人確認書類のアッロードについて
+              %i.fas.fa-chevron-right
+
+          .main__container__r-container__register__form
+            お名前
+          .main__container__r-container__register__info
+            = @user.first_name
+            = @user.last_name
+          .main__container__r-container__register__form
+            お名前カナ
+          .main__container__r-container__register__info
+            = @user.first_name_kana
+            = @user.last_name_kana
+          .main__container__r-container__register__form
+            生年月日
+          .main__container__r-container__register__info
+            = @user.birthday
+          .main__container__r-container__register__form
+
+            .main__container__r-container__register__form__place
+              郵便番号
+            .main__container__r-container__register__form__any
+              任意
+          .main__container__r-container__register__form__edit
+            = f.text_area :postal_code, class:"person"
+          .main__container__r-container__register__form
+            .main__container__r-container__register__form__place
+              都道府県
+            .main__container__r-container__register__form__any
+              任意
+          .main__container__r-container__register__form__p-edit
+            %rabel{name:"p-rabel",class:"label"}
+              = f.select :prefecture, [["北海道","1"], ["青森県","2"],  ["岩手県","3"], ["宮城県","4"],["秋田県","4"],["山形県","5"],["福島県","6"],["東京都","7"],["神奈川県","8"],["埼玉県","9"],["千葉県","10"],["茨城県","11"],["栃木県","12"],["群馬県","13"],["秋田県","14"],["山梨県","15"],["長野県","16"],["富山県","17"],["石川県","18"],["福井県","19"],["愛知県","20"],["岐阜県","21"],["静岡県","22"],["三重県","23"],["大阪府","24"],["兵庫県","25"],["京都府","26"],["滋賀県","27"],["奈良県","28"],["和歌山県","29"],["鳥取県","30"],["島根県","31"],["岡山県","32"],["広島県","33"],["山口県","34"],["徳島県","35"],["香川県","36"],["愛媛県","37"],["高知県","38"],["福岡県","39"],["佐賀県","40"],["長崎県","41"],["熊本県","42"],["大分県","43"],["宮城県","44"],["秋田県","45"],["鹿児島県","46"],["沖縄県","47"] ],class:"prefecture" 
+              %i.fas.fa-chevron-down
+          .main__container__r-container__register__form
+            .main__container__r-container__register__form__place
+              市町村
+            .main__container__r-container__register__form__any
+              任意
+          .main__container__r-container__register__form__edit
+            = f.text_area :city, class:"person"
+          .main__container__r-container__register__form
+            .main__container__r-container__register__form__place
+              番地
+            .main__container__r-container__register__form__any
+              任意
+          .main__container__r-container__register__form__edit
+            = f.text_area :house_number, class:"person"
+          .main__container__r-container__register__form
+            .main__container__r-container__register__form__place
+              建物名
+            .main__container__r-container__register__form__any
+              任意
+          .main__container__r-container__register__form__edit
+            = f.text_area :building, class:"person"
+        .main__container__r-container__register__btn
+          = f.submit '登録する', class:'register' 
+        .main__container__r-container__register__r-info
+          = link_to "#", class:"register-info" do
+            本人情報の登録について
+            %i.fas.fa-chevron-right
   =render "shared/footer"      

--- a/app/views/users/_sessions-header.html.haml
+++ b/app/views/users/_sessions-header.html.haml
@@ -1,7 +1,8 @@
 .users-session
   .users-session__header
     .users-session__header__logo
-      =image_tag "fmarket_logo_red.svg"
+      = link_to root_path do
+        =image_tag "fmarket_logo_red.svg"
     .users-session__header__process
       .users-session__header__process__info
         会員情報

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,7 @@ Rails.application.routes.draw do
           patch 'profile_edit'
           get 'payment'
           get 'register'
+          patch 'register_edit'
           get 'logout'
         end
       end


### PR DESCRIPTION
#What
①マイページ→サイドバー→本人確認情報のページの住所編集機能を追加
②新規登録ページのヘッダーのロゴにルートパスを付与

#Why
ユーザーが本人情報の編集が必要な場合に必要であるため
①<img width="1296" alt="29224c4f10a50ea1c88112f78de69e3c" src="https://user-images.githubusercontent.com/58457640/73251526-7c3a9700-41fc-11ea-994a-fde63116d451.png">
②https://i.gyazo.com/5bd021dd4ef6eca9686f9dff74a4f97f.mp4
