### PR TITLE
フラッシュメッセージの設定＆addressカラムの修正（任意箇所の入力問題解消のため）

### DIFF
--- a/app/assets/stylesheets/users/_new-user-top.scss
+++ b/app/assets/stylesheets/users/_new-user-top.scss
@@ -1,3 +1,18 @@
+.notifications {
+  color: black;
+  text-align: center;  
+  font-size: 20px;
+
+  .notice {
+    background-color: lightBlue;
+    height: 100px;
+    line-height: 100px;
+  }
+
+  .alert {
+    background-color: orange;
+  }
+}
 .new-user-top{
   background-color: #f5f5f5;
   box-sizing: border-box;

--- a/app/assets/stylesheets/users/_new-user-top.scss
+++ b/app/assets/stylesheets/users/_new-user-top.scss
@@ -5,8 +5,8 @@
 
   .notice {
     background-color: lightBlue;
-    height: 100px;
-    line-height: 100px;
+    height: 70px;
+    line-height: 70px;
   }
 
   .alert {

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -34,7 +34,7 @@ class SignupController < ApplicationController
     session[:city] = address_params[:city]
     session[:house_number] = address_params[:house_number]
     session[:building] = address_params[:building]
-    session[:tel] = address_params[:tel]
+    session[:building_tel] = address_params[:building_tel]
     @address = Address.new
   end
 
@@ -66,7 +66,7 @@ class SignupController < ApplicationController
       city: session[:city], 
       house_number: session[:house_number], 
       building: session[:building],
-      tel: session[:tel],
+      building_tel: session[:building_tel],
       user_id: @user.id
     )
 
@@ -75,7 +75,8 @@ class SignupController < ApplicationController
       session[:id] = @user.id
       redirect_to session5_signup_index_path
     else
-      redirect_to root_path
+      flash[:notice] = '登録ができませんでした。再度新規登録をお願い致します。'
+      redirect_to user_top_signup_index_path
     end
   end
 
@@ -90,7 +91,7 @@ class SignupController < ApplicationController
   end
 
   def address_params
-    params.require(:user).require(:addresses).permit(:postal_code, :prefecture, :city, :house_number, :building, :tel )
+    params.require(:user).require(:addresses).permit(:postal_code, :prefecture, :city, :house_number, :building, :building_tel )
   end
 
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -9,5 +9,8 @@
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
     %script{src: "//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js", type: "text/javascript"}
   %body
+    .notifications
+      - flash.each do |key, value|
+        = content_tag(:div, value, class: key)
     = render 'shared/exhibition-btn'
     = yield

--- a/app/views/signup/session3.html.haml
+++ b/app/views/signup/session3.html.haml
@@ -60,7 +60,7 @@
               電話
               %span{class: "optional"}任意
             .sign-up-session3__body__contents__tel__form
-              = i.text_field :tel, class: "form building-form", placeholder: "例）0120828828"
+              = i.text_field :building_tel, class: "form building-form", placeholder: "例）0120828828"
           .sign-up-session3__body__contents__next
             =f.submit "次へ進む",class:"session3-next"
   .sign-up-session3__footer

--- a/app/views/signup/user_top.html.haml
+++ b/app/views/signup/user_top.html.haml
@@ -1,6 +1,4 @@
-.notifications
-  - flash.each do |key, value|
-    = content_tag(:div, value, class: key)
+
 .new-user-top
   .new-user-top__header
     = render 'users/sessions-header'

--- a/app/views/signup/user_top.html.haml
+++ b/app/views/signup/user_top.html.haml
@@ -1,3 +1,6 @@
+.notifications
+  - flash.each do |key, value|
+    = content_tag(:div, value, class: key)
 .new-user-top
   .new-user-top__header
     = render 'users/sessions-header'

--- a/db/migrate/20200110093109_create_addresses.rb
+++ b/db/migrate/20200110093109_create_addresses.rb
@@ -6,7 +6,7 @@ class CreateAddresses < ActiveRecord::Migration[5.0]
       t.string     :city,         null: false
       t.string     :house_number, null: false
       t.string     :building
-      t.string     :tel
+      t.string     :building_tel
       t.references :user,         foreign_key: true
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,7 +18,7 @@ ActiveRecord::Schema.define(version: 20200123055656) do
     t.string   "city",         null: false
     t.string   "house_number", null: false
     t.string   "building"
-    t.string   "tel"
+    t.string   "building_tel"
     t.integer  "user_id"
     t.datetime "created_at",   null: false
     t.datetime "updated_at",   null: false


### PR DESCRIPTION
#What
①ユーザー新規登録の登録失敗時のフラッシュメッセージを設定
②任意箇所（addressの建物、電話）が入力されないと登録できない問題を解消するためにaddressテーブルのtelを変更。
③ログイン・ログアウトの確認のフラッシュメッセージ

#Why
①ユーザー新規登録が完了できたかどうかをわかりやすくするため
②userテーブルのtelとaddressテーブルのtellのカラム名が同じのため競合しバリデーションがかかってしまっていたために名前を修正することにより任意の箇所は入力しなくても登録できるようになった。
③③ログイン・ログアウトを明示的にわかるため

①https://i.gyazo.com/0581513e017ae7cb479acb3cbf69dcb0.mp4
②https://i.gyazo.com/67e692804a1296e84ea51b5879ce0c26.mp4
③https://i.gyazo.com/53377b3c86602d122ea17f4f6457a21e.mp4

